### PR TITLE
Fix bug where the `currentChannel` in the popup is not synchronized with the backend value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 <!--Releasenotes start-->
 - Fixed a bug where the channel name displayed in the popup would sometimes not be synchronized with the one that is used in the backend.
+- Fixed a bug where it would not be possible to set the shuffle percentage to 100% if another value was previously set.
 <!--Releasenotes end-->
 
 ## v1.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## v1.4.3
+## v1.4.4
 
 <!--Releasenotes start-->
-- Fixed a bug occurring when a channel has no videos.
+- Fixed a bug where the channel name displayed in the popup would sometimes not be synchronized with the one that is used in the backend.
 <!--Releasenotes end-->
+
+## v1.4.3
+
+- Fixed a bug occurring when a channel has no videos.
 
 ## v1.4.2
 

--- a/extension/html/shufflingPage.html
+++ b/extension/html/shufflingPage.html
@@ -20,7 +20,7 @@
 
 		<br>
 		<div id="shufflingInProgressElements">
-			<p><i>NOTE: Closing this window will cancel the shuffle!</i></p>
+			<p><i>Closing this window will cancel the shuffle!</i></p>
 
 			<br>
 			<br>

--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -90,7 +90,7 @@ async function validateConfigSync() {
 		// These two properties influence the behavior of the "shuffle" button
 		"shuffleOpenInNewTabOption": false,
 		"shuffleOpenAsPlaylistOption": true,
-		// channelSettings is a dictionary of channelID -> percentage pairs
+		// channelSettings is a dictionary of channelID -> Dictionary of channel settings
 		"channelSettings": {},
 		// These two properties are used by the popup to determine which channel's settings to show
 		"currentChannelId": null,
@@ -176,8 +176,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 			sendResponse("New configSync set.");
 			break;
 		default:
-			console.log(`Unknown command: ${request.command}`);
-			sendResponse(`Unknown command: ${request.command}`);
+			console.log(`Unknown command: ${request.command} (service worker). Hopefully another message listener will handle it.`);
+			sendResponse(`Unknown command: ${request.command} (service worker). Hopefully another message listener will handle it.`);
 			break;
 	}
 	return true;

--- a/extension/js/buildShuffleButton.js
+++ b/extension/js/buildShuffleButton.js
@@ -36,7 +36,7 @@ function buildShuffleButton(pageType, channelId) {
 		document.getElementById(buttonDivID).style.display = "flex";
 
 		// Update the channelId
-		document.getElementById(buttonDivID).children[0].children[0].children[0].children.namedItem('channelId').innerHTML = channelId ?? "";
+		document.getElementById(buttonDivID).children[0].children[0].children[0].children.namedItem('channelId').innerText = channelId ?? "";
 
 		return;
 	}

--- a/extension/js/popup/popup.js
+++ b/extension/js/popup/popup.js
@@ -6,3 +6,18 @@ const domElements = getDomElements();
 await setDomElementValuesFromConfig(domElements, configSync);
 
 await setDomElemenEventListeners(domElements, configSync);
+
+// IMPORTANT: Only one message handler can send a response. This is the one in the background script for us, so we CANNOT send a response here!
+chrome.runtime.onMessage.addListener(async function (request, sender, sendResponse) {
+	switch (request.command) {
+		case "updateCurrentChannel":
+			// The currentChannelId and currentChannelName have been updated in the configSync
+			configSync = await fetchConfigSync();
+			// We need to update the relevant DOM elements with the new channel name
+			updateDomElementsWithChannelName(domElements, configSync);
+			break;
+		default:
+			console.log(`Unknown command: ${request.command} (popup). Hopefully another message listener will handle it.`);
+			break;
+	}
+});

--- a/extension/js/popup/popupUtils.js
+++ b/extension/js/popup/popupUtils.js
@@ -98,3 +98,19 @@ function setChannelSetting(channelId, setting, value) {
 	configSync.channelSettings = channelSettings;
 	setSyncStorageValue("channelSettings", channelSettings, configSync);
 }
+
+function removeChannelSetting(channelId, setting) {
+	let channelSettings = configSync.channelSettings;
+	if (!channelSettings[channelId]) {
+		return;
+	}
+	delete channelSettings[channelId][setting];
+
+	// If the channel settings object is empty, remove it entirely
+	if (getLength(channelSettings[channelId]) === 0) {
+		delete channelSettings[channelId];
+	}
+
+	configSync.channelSettings = channelSettings;
+	setSyncStorageValue("channelSettings", channelSettings, configSync);
+}

--- a/extension/js/popup/shufflingPage.js
+++ b/extension/js/popup/shufflingPage.js
@@ -40,7 +40,7 @@ async function shuffleButtonClicked() {
 
 		var configSync = await fetchConfigSync();
 
-		domElements.shufflingFromChannelHeading.innerHTML = configSync.currentChannelName;
+		domElements.shufflingFromChannelHeading.innerText = configSync.currentChannelName;
 
 		await chooseRandomVideo(configSync.currentChannelId, true, domElements.fetchPercentageNotice);
 		// Remove the port's onDisconnect listener, as we have successfully opened the video and the service worker won't freeze
@@ -49,23 +49,23 @@ async function shuffleButtonClicked() {
 		console.error(error.stack);
 		console.error(error.message);
 
-		let displayText = "";
+		let errorHeading = "";
 		switch (error.name) {
 			case "RandomYoutubeVideoError":
-				displayText = `Error ${error.code}`;
+				errorHeading = `Error ${error.code}`;
 				break;
 			case "YoutubeAPIError":
-				displayText = `API Error ${error.code}`;
+				errorHeading = `API Error ${error.code}`;
 				break;
 			default:
-				displayText = `Unknown Error`;
+				errorHeading = `Unknown Error`;
 		}
 
-		const errorMessage = `${error.message ?? ""}${error.reason ? "<br>" + error.reason : ""}${error.solveHint ? "<br>" + error.solveHint : ""}${error.showTrace ? "<br><br>" + error.stack : ""}`;
+		const errorMessage = `${error.message ?? ""}${error.reason ? "\n" + error.reason : ""}${error.solveHint ? "\n" + error.solveHint : ""}${error.showTrace !== false ? "\n\n" + error.stack : ""}`;
 
-		// Immediately display the error and stop other text changes
-		setDOMTextWithDelay(domElements.fetchPercentageNotice, displayText, 0, changeToken, true);
-		domElements.shuffleErrorText.innerHTML = errorMessage;
+		// Immediately display the error
+		domElements.fetchPercentageNotice.innerText = errorHeading;
+		domElements.shuffleErrorText.innerText = errorMessage;
 		domElements.shuffleErrorText.classList.remove("hidden");
 
 		// Stop displaying the elements that are only shown while shuffling

--- a/extension/js/utils.js
+++ b/extension/js/utils.js
@@ -29,25 +29,12 @@ function isVideoUrl(url) {
 	return urlParts[3].startsWith("watch?v=");
 }
 
-// ----- DOM -----
+// ----- Small utilities -----
 
 // Waits for a certain amount of milliseconds
 function delay(ms) {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
-
-function setDOMTextWithDelay(textElement, newText, delayMS, changeToken, finalizes = false) {
-	// Sets the innerText of a (text) DOM element after a delay, if the changeToken indicates it is still valid
-	delay(delayMS).then(() => {
-		if (!changeToken.isFinalized) {
-			textElement.innerText = newText;
-			// If the caller wants to stop others from setting the value to something else
-			changeToken.isFinalized = finalizes;
-		}
-	});
-}
-
-// ----- Objects -----
 
 // Determines if an object is empty
 function isEmpty(obj) {

--- a/extension/js/utils.js
+++ b/extension/js/utils.js
@@ -37,11 +37,10 @@ function delay(ms) {
 }
 
 function setDOMTextWithDelay(textElement, newText, delayMS, changeToken, finalizes = false) {
-	// Sets the innerHTML of a (text) DOM element after a delay, if something else hasn't changed it yet
-	// i.e. only one function can change the text among all functions that were passed the same changeToken
+	// Sets the innerText of a (text) DOM element after a delay, if the changeToken indicates it is still valid
 	delay(delayMS).then(() => {
 		if (!changeToken.isFinalized) {
-			textElement.innerHTML = newText;
+			textElement.innerText = newText;
 			// If the caller wants to stop others from setting the value to something else
 			changeToken.isFinalized = finalizes;
 		}


### PR DESCRIPTION
Closes #116 
Also, replaced calls to innerHTML with innerText to prevent accidentally removing id, class etc. information.
Therefore, we no longer need the `setDOMTextWithDelay`, which was removed.

Fixed a bug where you would be unable to reset the shuffle percentage to 100% after another percentage was already set.