### PR TITLE
Save the playlist if a non-fatal error is encountered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - The playlist that is opened when shuffling (if the option is enabled) now has a better title and tooltip.
 - The shuffle button now feels more responsive when clicked, and will give more information if it takes a bit longer to shuffle.
 - The popup now feels smoother in some places, and will make it clearer when some inputs are invalid.
+- If certain errors are encountered, the playlist will still be saved locally and in the database, to speed up the next shuffle.
 - Fixed bugs that would prevent some initialization logic to run after the extension is updated.
 <!--Releasenotes end-->
 

--- a/src/content.js
+++ b/src/content.js
@@ -150,7 +150,8 @@ async function shuffleVideos() {
 					code: "RYV-9",
 					message: "The extension was unable to find from which channel to shuffle.",
 					solveHint: "The page will now reload, after which the button should work again. If it doesn't, please report this issue on GitHub!",
-					showTrace: false
+					showTrace: false,
+					canSavePlaylist: false
 				}
 			)
 		}

--- a/src/utils.js
+++ b/src/utils.js
@@ -87,24 +87,27 @@ export function addHours(date, hours) {
 
 // ----- Errors -----
 export class RandomYoutubeVideoError extends Error {
-	constructor({ code = "RYV-0", message = "", solveHint = "", showTrace = true }) {
+	constructor({ code = "RYV-0", message = "", solveHint = "", showTrace = true, canSavePlaylist = false }) {
 		super(message);
 		this.code = code;
 		this.message = message;
 		this.solveHint = solveHint;
 		this.showTrace = showTrace;
+		// This should be set to true for 'non-fatal' errors, where the playlist is in a safe state
+		this.canSavePlaylist = canSavePlaylist;
 		this.name = "RandomYoutubeVideoError";
 	}
 }
 
 export class YoutubeAPIError extends RandomYoutubeVideoError {
-	constructor(code = "YAPI-0", message = "", reason = "", solveHint = "", showTrace = true) {
+	constructor(code = "YAPI-0", message = "", reason = "", solveHint = "", showTrace = true, canSavePlaylist = false) {
 		super(message);
 		this.code = code;
 		this.message = message;
 		this.reason = reason;
 		this.solveHint = solveHint;
 		this.showTrace = showTrace;
+		this.canSavePlaylist = canSavePlaylist;
 		this.name = "YoutubeAPIError";
 	}
 }


### PR DESCRIPTION
Closes #244 

Some errors can be classified as 'Bad Request', e.g. bad shuffle filters for the current channel.
In these cases, the playlist that was fetched is still valid, so we can save it locally/upload it to the database.