### PR TITLE
Inject content script at `document_start`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
-## v3.1.7
+## v3.1.8-beta
 
 <!--Releasenotes start-->
+- Fixed a bug where the shuffle button would sometimes not be added to the page if it was opened directly from a new tab.
+- Fixed a bug where the playlist created by the extension would sometimes not be renamed correctly.
+<!--Releasenotes end-->
+
+## v3.1.7
+
 - The extensions's news page can now be updated with breaking changes or other important information without the need to update the extension itself.
 - Fixed some dynamic content on the News page.
 - Added a hint in the popup if no channel has yet been visited.
 - Removed some unneeded scripts from the extension's pages.
-<!--Releasenotes end-->
 
 ## v3.1.6
 

--- a/src/content.js
+++ b/src/content.js
@@ -100,7 +100,7 @@ async function startDOMObserver(event) {
 async function channelDetectedAction(pageType, channelId, channelName, eventVersion) {
 	// It might be that we got to this page after shuffling, in which case we want to check if there is a 'Untitled List' that we can rename
 	// We do this before anything else to prevent the previous text from showing
-	if (getPageTypeFromURL(window.location.href) === "video") {
+	if (pageType === "video") {
 		tryRenameUntitledList();
 	}
 

--- a/src/content.js
+++ b/src/content.js
@@ -22,11 +22,6 @@ if (videoShuffleButton || channelShuffleButton || shortShuffleButton) {
 	window.location.reload(true);
 }
 
-// It might be that we got to this page after shuffling, in which case we want to check if there is a 'Untitled List' that we can rename
-if (getPageTypeFromURL(window.location.href) === "video") {
-	tryRenameUntitledList();
-}
-
 // After every navigation event, we need to check if this page needs a 'Shuffle' button
 document.addEventListener("yt-navigate-finish", startDOMObserver);
 
@@ -103,6 +98,12 @@ async function startDOMObserver(event) {
 }
 
 async function channelDetectedAction(pageType, channelId, channelName, eventVersion) {
+	// It might be that we got to this page after shuffling, in which case we want to check if there is a 'Untitled List' that we can rename
+	// We do this before anything else to prevent the previous text from showing
+	if (getPageTypeFromURL(window.location.href) === "video") {
+		tryRenameUntitledList();
+	}
+
 	// We can get an error here if the extension context was invalidated and the user navigates without reloading the page
 	try {
 		// If we are still connected to the background worker, we can send a message to test the connection

--- a/src/content.js
+++ b/src/content.js
@@ -22,6 +22,11 @@ if (videoShuffleButton || channelShuffleButton || shortShuffleButton) {
 	window.location.reload(true);
 }
 
+// It might be that we got to this page after shuffling, in which case we want to check if there is a 'Untitled List' that we can rename
+if (getPageTypeFromURL(window.location.href) === "video") {
+	tryRenameUntitledList();
+}
+
 // After every navigation event, we need to check if this page needs a 'Shuffle' button
 document.addEventListener("yt-navigate-finish", startDOMObserver);
 
@@ -98,12 +103,6 @@ async function startDOMObserver(event) {
 }
 
 async function channelDetectedAction(pageType, channelId, channelName, eventVersion) {
-	// It might be that we got here after shuffling, in which case we want to check if there is a 'Untitled List' that we can rename
-	// We do this before anything else to prevent the previous text from showing shortly
-	if (pageType === "video") {
-		tryRenameUntitledList();
-	}
-
 	// We can get an error here if the extension context was invalidated and the user navigates without reloading the page
 	try {
 		// If we are still connected to the background worker, we can send a message to test the connection

--- a/src/domManipulation.js
+++ b/src/domManipulation.js
@@ -139,8 +139,6 @@ export function buildShuffleButton(pageType, channelId, eventVersion, clickHandl
 	});
 }
 
-// With the way that YouTube handles navigation, the playlist title somehow won't get updated correctly when navigating if we change it here at any point
-// So we need to change it back if the user moves to a different playlist
 export function tryRenameUntitledList() {
 	let mainPlaylistElement = document.querySelector('ytd-playlist-panel-renderer#playlist.style-scope.ytd-watch-flexy').querySelector('yt-formatted-string.title.style-scope.ytd-playlist-panel-renderer');
 	let collapsedPlaylistElement = document.querySelector('ytd-playlist-panel-renderer#playlist.style-scope.ytd-watch-flexy').querySelector('yt-formatted-string.byline-title.style-scope.ytd-playlist-panel-renderer');
@@ -149,6 +147,8 @@ export function tryRenameUntitledList() {
 		if (playlistType && window.location.href.includes("&list=TL") && playlistType.title == "Untitled List") {
 			playlistType.innerText = "Random YouTube Video - Playlist";
 			playlistType.title = "This playlist is unlisted, temporary and cannot be saved. Until it is removed by YouTube (which will happen automatically), you can revisit it using the link in the URL bar.";
+			// With the way that YouTube handles navigation, the playlist title somehow won't get updated correctly when navigating if we change it here at any point
+			// So we need to change it back if the user moves to a different playlist
 		} else if (playlistType) {
 			playlistType.innerText = playlistType.title;
 		}

--- a/src/domManipulation.js
+++ b/src/domManipulation.js
@@ -139,14 +139,24 @@ export function buildShuffleButton(pageType, channelId, eventVersion, clickHandl
 	});
 }
 
-export function tryRenameUntitledList() {
-	let mainPlaylistElement = document.querySelector('ytd-playlist-panel-renderer#playlist.style-scope.ytd-watch-flexy').querySelector('yt-formatted-string.title.style-scope.ytd-playlist-panel-renderer');
-	let collapsedPlaylistElement = document.querySelector('ytd-playlist-panel-renderer#playlist.style-scope.ytd-watch-flexy').querySelector('yt-formatted-string.byline-title.style-scope.ytd-playlist-panel-renderer');
+export function tryRenameUntitledList(attempt = 1) {
+	let mainPlaylistElement = document.querySelector('ytd-playlist-panel-renderer#playlist.style-scope.ytd-watch-flexy')?.querySelector('yt-formatted-string.title.style-scope.ytd-playlist-panel-renderer');
+	let collapsedPlaylistElement = document.querySelector('ytd-playlist-panel-renderer#playlist.style-scope.ytd-watch-flexy')?.querySelector('yt-formatted-string.byline-title.style-scope.ytd-playlist-panel-renderer');
+
+	// Retry this a few times, in case the element has not yet loaded in
+	if (!mainPlaylistElement || !collapsedPlaylistElement) {
+		if (attempt <= 10) {
+			setTimeout(() => tryRenameUntitledList(attempt + 1), 200);
+			return;
+		} else {
+			return;
+		}
+	}
 
 	for (let playlistType of [mainPlaylistElement, collapsedPlaylistElement]) {
 		if (playlistType && window.location.href.includes("&list=TL") && playlistType.title == "Untitled List") {
 			playlistType.innerText = "Random YouTube Video - Playlist";
-			playlistType.title = "This playlist is unlisted, temporary and cannot be saved. Until it is removed by YouTube (which will happen automatically), you can revisit it using the link in the URL bar.";
+			playlistType.title = "This playlist is unlisted, temporary and cannot be saved. You can visit it using the link in the URL bar until it is removed by YouTube, which will happen automatically.";
 			// With the way that YouTube handles navigation, the playlist title somehow won't get updated correctly when navigating if we change it here at any point
 			// So we need to change it back if the user moves to a different playlist
 		} else if (playlistType) {

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Random YouTube Video",
 	"description": "Customize, shuffle and play random videos from any YouTube channel.",
 	"version": "3.1.7",
-	"version_name": "3.1.7",
+	"version_name": "3.1.8-beta",
 	"manifest_version": 3,
 	"content_scripts": [
 		{
@@ -12,7 +12,7 @@
 			"matches": [
 				"*://*.youtube.com/*"
 			],
-			"run_at": "document_end"
+			"run_at": "document_start"
 		}
 	],
 	"permissions": [


### PR DESCRIPTION
Closes #308 

Injecting the content script earlier means it is added before any DOM or events fire, which greatly decreases false negatives, where a channel is not detected due to the `yt-navigate-finish` event firing before the content script can attach an event listener.